### PR TITLE
Prevents a double free on string-encoded tilelayer data.

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -881,7 +881,9 @@ void layers_free(Layer* layers, size_t layer_count) {
         free_objects(layers[i].objects, layers[i].object_count);
         free_chunks(layers[i].chunks, layers[i].chunk_count);
         free(layers[i].properties);
-        free(layers[i].data_uint);
+        if (!layers[i].data_is_str) {
+          free(layers[i].data_uint);
+        }
 
         layers_free(layers[i].layers, layers[i].layer_count);
     }


### PR DESCRIPTION
Hi there!

I was using your nifty library for a tilemap with string-encoded tilelayer data and seeing double frees. As far as I can see, string-encoded data is extracted using `json_unpack_ex`, which seems to use an internally managed string, whereas integer data is copied.

If this is all true, string-encoded data shouldn't be freed, since it's disposed of when its reference count goes to zero.