### PR TITLE
Text, polygon, and polyline objects are now unpacked from objectgroup layers.

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -293,7 +293,7 @@ Object* unpack_objects(json_t* objects) {
                 "s:s, s?s, s?s,"
                 "s?i, s:i,"
                 "s:F, s:F, s:F, s:F, s:F,"
-                "s?o"
+                "s?o, s?o, s?o, s?o"
                 "}",
                 "ellipse",
                 &ret[idx].ellipse,


### PR DESCRIPTION
I don't know how much this has been tested yet, but I'm using this on some data with polygon and polyline objects, and can provide some examples if it's helpful.