### PR TITLE
Make git submodules use HTTPS instead of SSH link, also fix building on Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/Unity"]
 	path = test/Unity
-	url = git@github.com:ThrowTheSwitch/Unity.git
+	url = https://github.com/ThrowTheSwitch/Unity.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,10 @@ target_compile_definitions(tmj PUBLIC
     LIBTMJ_VERSION="${PROJECT_VERSION}"
 )
 
+
 # Control symbol visibility
 if(NOT WIN32 AND NOT APPLE)
-    target_link_options(tmj PRIVATE "LINKER:--version-script=src/tmj.sym")
+    target_link_options(tmj PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/tmj.sym")
 endif()
 
 # Set include directories


### PR DESCRIPTION
This fixes an issue I was having when attempting to use this with FetchContent in CMake.
For some reason, it was set to use an SSH link for cloning the Unity tests instead of HTTPS, so I have changed the link.

With this change, you will no longer get a SSH error when trying to clone with the submodules.

Also, I fixed building this project on Linux by disabling this line in the CMakeLists.txt
`target_link_options(tmj PRIVATE "LINKER:--version-script=src/tmj.sym")`

I'm not exactly sure if that is needed or what this option does honestly.
